### PR TITLE
feat: use the path parameter type urls for sharing

### DIFF
--- a/app/src/main/java/com/perol/asdpl/pixivez/activity/PictureActivity.kt
+++ b/app/src/main/java/com/perol/asdpl/pixivez/activity/PictureActivity.kt
@@ -191,7 +191,7 @@ class PictureActivity : RinkActivity() {
         textIntent.type = "text/plain"
         textIntent.putExtra(
             Intent.EXTRA_TEXT,
-            "https://www.pixiv.net/member_illust.php?illust_id=${illustIdList!![nowPosition]}&mode=medium"
+            "https://www.pixiv.net/artworks/{illustIdList!![nowPosition]}"
         )
         startActivity(Intent.createChooser(textIntent, getString(R.string.share)))
     }

--- a/app/src/main/java/com/perol/asdpl/pixivez/adapters/PictureXAdapter.kt
+++ b/app/src/main/java/com/perol/asdpl/pixivez/adapters/PictureXAdapter.kt
@@ -329,7 +329,7 @@ class PictureXAdapter(
                 textIntent.type = "text/plain"
                 textIntent.putExtra(
                     Intent.EXTRA_TEXT,
-                    "https://www.pixiv.net/member_illust.php?illust_id=${illust.id}&mode=medium"
+                    "https://www.pixiv.net/artworks/${illust.id}"
                 )
                 mContext.startActivity(Intent.createChooser(textIntent, mContext.getString(R.string.share)))
             }


### PR DESCRIPTION
Mostly a convenience thing.

Use the newer path parameter based urls instead of query based when sharing an artwork, ie.
`https://www.pixiv.net/member_illust.php?illust_id=108831441` &rarr; `https://www.pixiv.net/en/artworks/108831441`

This matches the current behavior of pixiv.net when using the older url format