### PR TITLE
Tighten WebView posture in OKWebViewActivity and NewUserActivity

### DIFF
--- a/app/src/main/java/com/perol/asdpl/pixivez/ui/OKWebViewActivity.kt
+++ b/app/src/main/java/com/perol/asdpl/pixivez/ui/OKWebViewActivity.kt
@@ -299,7 +299,11 @@ class OKWebViewActivity : RinkActivity() {
         settings.javaScriptEnabled = true
         settings.domStorageEnabled = true
         settings.databaseEnabled = true
-        settings.allowUniversalAccessFromFileURLs = true
+        // allowUniversalAccessFromFileURLs only takes effect when the
+        // WebView's main frame is a file:// URL. The activity is opened
+        // with an https Pixiv OK URL (see loadUrl above), so this flag is
+        // not load-bearing here. It is a CWE-200 sandbox-escape vector
+        // when left on, so drop it.
         settings.cacheMode = WebSettings.LOAD_DEFAULT
         // settings.setAppCacheEnabled(true)
         WebviewDnsInterceptUtil.userAgentString = settings.userAgentString

--- a/app/src/main/java/com/perol/asdpl/pixivez/ui/account/NewUserActivity.kt
+++ b/app/src/main/java/com/perol/asdpl/pixivez/ui/account/NewUserActivity.kt
@@ -97,7 +97,11 @@ class NewUserActivity : RinkActivity() {
         webSettings.displayZoomControls = false
         webSettings.loadWithOverviewMode = true
         webSettings.useWideViewPort = true
-        webSettings.mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
+        // COMPATIBILITY_MODE keeps passive sub-resources (images, fonts)
+        // loading on the https Pixiv login page while blocking active
+        // mixed content like remote scripts. ALWAYS_ALLOW is the
+        // strictly less safe choice in the WebSettings javadoc.
+        webSettings.mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
             CookieManager.getInstance().removeAllCookies(null)


### PR DESCRIPTION
Closes #117.

Two WebView setups still toggle settings that are less safe than the actual load paths ask for.

### OKWebViewActivity

`OKWebViewActivity` is opened with an https Pixiv OK URL and sets:

```kotlin
settings.allowUniversalAccessFromFileURLs = true
```

The flag only takes effect when the main frame is a `file://` URL, which never happens here, so it is not load-bearing for any path. `allowUniversalAccessFromFileURLs` is the universal-XSS flag from the `WebSettings` javadoc and a CWE-200 sandbox-escape vector when left on. Drop it.

### NewUserActivity

The Pixiv login WebView sets:

```kotlin
webSettings.mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
```

`ALWAYS_ALLOW` lets an https page load every kind of http sub-resource, including remote scripts, and is the strictly less safe choice in the `WebSettings` javadoc. Replace with `MIXED_CONTENT_COMPATIBILITY_MODE`, which keeps passive sub-resources (images, fonts) loading while blocking active mixed content like remote scripts. This matches how Chrome treats mixed content in the address bar and is the right default for the login flow.

### Scope

Two files, two semantic changes, plus short inline comments explaining the reasoning. No other WebView setting is touched. The `onReceivedSslError` override in `OKWebViewActivity` is already interactive (`MaterialDialogs` confirm before `handler.proceed()`), so it is intentionally not part of this PR. The `setWebContentsDebuggingEnabled` line in `WebViewActivity.kt` is already commented out.